### PR TITLE
fix:EZAF-5993 Proper email is not displayed

### DIFF
--- a/superset/header_auth_security_manager.py
+++ b/superset/header_auth_security_manager.py
@@ -149,17 +149,20 @@ class HeaderAuthRemoteUserView(AuthView):
         
         # Get user info from request headers
         email = self.__get_email_from_request(request)
-        if email is None:
-            email = f'{username}@email.notfound'
         
         first_name = username
         last_name = "-"
         is_platform_admin = self.__PLATFORM_ADMIN_ROLE in self.__get_groups_from_request(request)
 
         token_payload = self.__get_decoded_jwt_from_request(request)
-        
-        first_name = token_payload.get("given_name", first_name)
-        last_name = token_payload.get("family_name", last_name)
+        if token_payload:
+            first_name = token_payload.get("given_name", first_name)
+            last_name = token_payload.get("family_name", last_name)
+            if email is None:
+                email = token_payload.get("email")
+ 
+        if email is None:
+            email = f'{username}@email.notfound'
         
         if is_platform_admin:
             role_name = ab_security_manager.auth_role_admin


### PR DESCRIPTION
[EZAF-5993](https://jira-pro.it.hpe.com:8443/browse/EZAF-5993) Proper email is not displayed

issue: After AD/LDAP support X-Auth-Request-Email header is no longer provided by the platform [see](https://jira-pro.it.hpe.com:8443/browse/EZAF-4683)
fix : getting email form jwt token payload

