### PR TITLE
EZAF-7696 Added psycopg2-binary dependency missed in OSS

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -261,6 +261,8 @@ prison==0.2.1
 prometheus_flask_exporter==0.22.4
 prompt-toolkit==3.0.44
     # via click-repl
+psycopg2-binary==2.9.10
+    # via apache-superset
 pyarrow==14.0.2
     # via apache-superset
 pyasn1==0.6.0


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
