### PR TITLE
[ezaf-12691]To resolve internal server error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -89,6 +89,8 @@ RUN mkdir -p ${PYTHONPATH} superset/static requirements superset-frontend apache
 COPY --chown=superset:superset pyproject.toml setup.py MANIFEST.in README.md ./
 
 RUN pip install --force-reinstall git+https://github.com/HPEEzmeral/ezua-gunicorn.git@master
+#EZAF-12691
+RUN RUN pip install --force-reinstall git+https://github.com/HPEEzmeral/Flask-AppBuilder.git@release/4.6.0
 # setup.py uses the version information in package.json
 COPY --chown=superset:superset superset-frontend/package.json superset-frontend/
 COPY --chown=superset:superset requirements/base.txt requirements/

--- a/Dockerfile
+++ b/Dockerfile
@@ -90,7 +90,7 @@ COPY --chown=superset:superset pyproject.toml setup.py MANIFEST.in README.md ./
 
 RUN pip install --force-reinstall git+https://github.com/HPEEzmeral/ezua-gunicorn.git@master
 #EZAF-12691
-RUN RUN pip install --force-reinstall git+https://github.com/HPEEzmeral/Flask-AppBuilder.git@release/4.6.0
+RUN pip install --force-reinstall git+https://github.com/HPEEzmeral/Flask-AppBuilder.git@release/4.6.0
 # setup.py uses the version information in package.json
 COPY --chown=superset:superset superset-frontend/package.json superset-frontend/
 COPY --chown=superset:superset requirements/base.txt requirements/


### PR DESCRIPTION
Getting Internal server error when a user is deleted and the user is trying to access the superset. The error looks like as below:

File "/usr/local/lib/python3.10/site-packages/flask_appbuilder/security/manager.py", line 2219, in load_user if user.is_active: AttributeError: 'NoneType' object has no attribute 'is_active

So adding condition to check user is not None.
PR for Flask-AppBuilder - https://github.com/HPEEzmeral/Flask-AppBuilder/pull/3

<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
